### PR TITLE
Add Repast agent specification and JSON exchange schema

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -1,3 +1,114 @@
-# Agents Instructions
+# Agents Specification
 
-今後の Codex 依頼用のメモとしてこのファイルを追加しました。詳細な指示は次のタスクで追記予定です。
+## Overview
+- **C++ (外回り施工フロー)**: 既存の施工シミュレータで外洋での施工スケジュールや船団の到着計算を実行する。計算結果は `docs/cppdoc` にまとめられている外回りモデルの変数・ロジックに基づく。
+- **Repast (港内モデル)**: 港内でのエージェント挙動、資材ハンドリング、動的なリソース配分を担当する。C++ 側から受け取った結果を、港内のエージェントとして具象化し、港内イベントの進行を管理する。
+- **棲み分け**: C++ で算出済みの値（船団到着、工程進捗など）を Repast のエージェント属性・スケジュールに反映し、港内での配置・積込・ヤード管理を Repast が細かく制御する。
+
+---
+
+## Agent: Vessel（作業船・輸送船）
+- **属性**
+  - `id: int`
+  - `position: (x: double, y: double)` — 港内平面での現在位置
+  - `capacity: double` — 最大積載可能量
+  - `cargo: List<Material>` — 積載中の資材
+  - `status: enum {待機, 移動中, 積込中, 荷下ろし中}`
+  - `assignedTask: Optional<Task>` — 現在指示されている作業内容
+- **行動**
+  - `moveTo(targetPosition)` — 指定座標に移動
+  - `load(material)` — クレーンから資材を受け取り積込
+  - `unload(material)` — ヤードや設置地点へ資材を降ろす
+  - `requestAssistance()` — クレーン等への作業要求を送信
+- **スケジュール**
+  - `@ScheduledMethod(start = 1, interval = 1)` — 各ステップで移動・積込・降ろし処理を進行
+- **通信**
+  - **C++ → Repast**: `arrival` イベントなどを通じて生成・更新される
+  - **Repast → C++**: `loaded` / `unloaded` などの完了通知を送信
+
+---
+
+## Agent: Crane（クレーン）
+- **属性**
+  - `id: int`
+  - `position: (x: double, y: double)`
+  - `radius: double` — 最大作業半径
+  - `rate: double` — 単位時間あたりの処理能力
+  - `status: enum {待機, 作業中}`
+  - `queue: List<CraneTask>` — 作業待ち行列
+- **行動**
+  - `assignTask(craneTask)` — 船・ヤードからの要求を受け付け
+  - `pick(material)` — 資材を掴み上げる
+  - `place(material, targetAgent)` — Vessel または Yard へ配置
+- **スケジュール**
+  - `@ScheduledMethod(start = 1, interval = 1)` — 待ち行列処理と作業状態更新
+- **通信**
+  - Repast 内で Vessel・Yard と同期し、必要に応じて完了報告を発火
+
+---
+
+## Agent: Yard（ヤード）
+- **属性**
+  - `id: int`
+  - `position: (x: double, y: double)`
+  - `capacity: double` — 保管容量
+  - `stock: List<Material>` — 現在保管中の資材
+  - `layout: YardLayout` — ヤード内配置情報
+- **行動**
+  - `store(material)` — 資材を受け入れ保管
+  - `retrieve(material)` — 指定資材を取り出しクレーンに引き渡す
+  - `inventoryReport()` — 現在在庫を集計し C++ 側と同期
+- **通信**
+  - 主に Repast 内で Vessel / Crane と連携し、必要に応じて在庫状況を C++ 側へ送信
+
+---
+
+## Agent: Material（資材）
+- **属性**
+  - `type: enum {Blade, Nacelle, Tower, Foundation}`
+  - `size: double`
+  - `weight: double`
+  - `state: enum {ヤード保管, 移動中, 船上, 設置完了}`
+  - `owner: AgentReference` — 所属先（Yard or Vessel）
+- **行動**
+  - `assignTo(agent)` — 所属先を更新
+  - `markInstalled()` — 設置完了を記録
+- **通信**
+  - 状態変化は Vessel / Yard を通じて共有され、必要に応じて C++ へレポート
+
+---
+
+## Agent: Worker（作業員／チーム）
+- **属性**
+  - `id: int`
+  - `skill: enum {溶接, 荷役, 組立}`
+  - `status: enum {待機, 作業中}`
+  - `assignedTask: Optional<Task>`
+- **行動**
+  - `workOn(target)` — 船内・ヤードでの作業に従事
+  - `reportProgress()` — 作業進捗を Repast 内に共有
+- **通信**
+  - 内部エージェント間の調整が中心。大きな工程進捗は C++ 側に送出
+
+---
+
+## C++ ↔ Repast 対応
+- **C++ 内で計算済みの値**
+  - 船団の到着時刻 → Repast の Vessel エージェント生成タイミングに利用
+  - 資材在庫量・需要 → Repast の Yard `stock` と連携
+  - 工程進捗（設置完了率など） → Material の `state` 更新と Worker の報告に反映
+- **Repast 側で扱うイベント**
+  - Vessel 到着・移動・積込
+  - Crane による積込／荷下ろし
+  - Yard の在庫変動
+  - Material / Worker 状態遷移
+- **通信イベント例**
+  - C++ → Repast: `arrival`, `supply_request`, `schedule_update`
+  - Repast → C++: `loaded`, `unloaded`, `installation_progress`
+
+---
+
+## 今後の拡張
+- `HelloAgent` を拡張した `VesselAgent` 実装へ本仕様をマッピングする。
+- Repast シミュレーション内でのスケジューリングと C++ 側イベント駆動ロジックを整合させる。
+- 本ファイルは追加のエージェント種別や属性が定義された場合に随時更新する。

--- a/ExchangeFormat.md
+++ b/ExchangeFormat.md
@@ -1,0 +1,293 @@
+# Exchange Format Specification
+
+港内 Repast モデルと外回り C++ モデルの間でやり取りする JSON メッセージ仕様。
+
+## 共通メッセージ構造
+- すべてのメッセージは UTF-8 エンコードの JSON オブジェクト。
+- `event` フィールドでイベント種別を指定する。
+- タイムスタンプは C++ 側で保持しているシミュレーション時間（UTC 相当）を `timestamp` として ISO-8601 文字列で送信する。
+- `simulationStep` は Repast 側のステップ番号。双方で同期させる際の参考値。
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SharedMessageEnvelope",
+  "type": "object",
+  "required": ["event", "messageId"],
+  "properties": {
+    "event": {
+      "type": "string",
+      "enum": [
+        "arrival",
+        "supply_request",
+        "schedule_update",
+        "loaded",
+        "unloaded",
+        "placement_completed",
+        "installation_progress"
+      ]
+    },
+    "messageId": { "type": "string", "description": "UUID などのユニーク ID" },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "simulationStep": { "type": "integer", "minimum": 0 },
+    "payload": { "type": "object" }
+  },
+  "additionalProperties": false
+}
+```
+
+以下では `payload` のスキーマをイベント種別ごとに定義する。
+
+---
+
+## C++ → Repast
+### `arrival`
+C++ 側で計算された船団の到着情報。
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ArrivalPayload",
+  "type": "object",
+  "required": ["vesselId", "eta", "cargo"],
+  "properties": {
+    "vesselId": { "type": "integer", "minimum": 0 },
+    "eta": { "type": "string", "format": "date-time", "description": "港内到着予定時刻" },
+    "position": {
+      "type": "object",
+      "required": ["x", "y"],
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" }
+      }
+    },
+    "capacity": { "type": "number", "minimum": 0 },
+    "cargo": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/material" }
+    }
+  },
+  "definitions": {
+    "material": {
+      "type": "object",
+      "required": ["type", "quantity"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["Blade", "Nacelle", "Tower", "Foundation"]
+        },
+        "quantity": { "type": "integer", "minimum": 1 }
+      }
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+### `supply_request`
+Repast 側で不足している資材を C++ 側に要求する。
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SupplyRequestPayload",
+  "type": "object",
+  "required": ["yardId", "materials"],
+  "properties": {
+    "yardId": { "type": "integer", "minimum": 0 },
+    "materials": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/material" }
+    },
+    "priority": { "type": "string", "enum": ["low", "normal", "high"], "default": "normal" }
+  },
+  "definitions": {
+    "material": {
+      "type": "object",
+      "required": ["type", "quantity"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["Blade", "Nacelle", "Tower", "Foundation"]
+        },
+        "quantity": { "type": "integer", "minimum": 1 }
+      }
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+### `schedule_update`
+C++ 側の工程計画変更を港内モデルに伝える。
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ScheduleUpdatePayload",
+  "type": "object",
+  "required": ["tasks"],
+  "properties": {
+    "tasks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["taskId", "vesselId", "start", "end"],
+        "properties": {
+          "taskId": { "type": "string" },
+          "vesselId": { "type": "integer", "minimum": 0 },
+          "start": { "type": "string", "format": "date-time" },
+          "end": { "type": "string", "format": "date-time" },
+          "description": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+---
+
+## Repast → C++
+### `loaded`
+港内での資材積込完了通知。
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "LoadedPayload",
+  "type": "object",
+  "required": ["vesselId", "materials"],
+  "properties": {
+    "vesselId": { "type": "integer", "minimum": 0 },
+    "materials": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/material" }
+    }
+  },
+  "definitions": {
+    "material": {
+      "type": "object",
+      "required": ["type", "quantity"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["Blade", "Nacelle", "Tower", "Foundation"]
+        },
+        "quantity": { "type": "integer", "minimum": 1 }
+      }
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+### `unloaded`
+港内での荷下ろし完了通知。
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UnloadedPayload",
+  "type": "object",
+  "required": ["vesselId", "materials", "yardId"],
+  "properties": {
+    "vesselId": { "type": "integer", "minimum": 0 },
+    "yardId": { "type": "integer", "minimum": 0 },
+    "materials": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/material" }
+    }
+  },
+  "definitions": {
+    "material": {
+      "type": "object",
+      "required": ["type", "quantity"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["Blade", "Nacelle", "Tower", "Foundation"]
+        },
+        "quantity": { "type": "integer", "minimum": 1 }
+      }
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+### `placement_completed`
+資材の港内配置が完了した際の通知。
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PlacementCompletedPayload",
+  "type": "object",
+  "required": ["materialId", "location"],
+  "properties": {
+    "materialId": { "type": "string" },
+    "location": {
+      "type": "object",
+      "required": ["x", "y"],
+      "properties": {
+        "x": { "type": "number" },
+        "y": { "type": "number" }
+      }
+    },
+    "vesselId": { "type": ["integer", "null"], "description": "関連する船舶 ID。無ければ null" }
+  },
+  "additionalProperties": false
+}
+```
+
+### `installation_progress`
+外回り工程に影響する進捗情報を送る。
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InstallationProgressPayload",
+  "type": "object",
+  "required": ["materialType", "completed"],
+  "properties": {
+    "materialType": {
+      "type": "string",
+      "enum": ["Blade", "Nacelle", "Tower", "Foundation"]
+    },
+    "completed": { "type": "integer", "minimum": 0 },
+    "total": { "type": "integer", "minimum": 0 },
+    "notes": { "type": "string" }
+  },
+  "additionalProperties": false
+}
+```
+
+---
+
+## 例: 到着通知
+
+```json
+{
+  "event": "arrival",
+  "messageId": "8d3f224c-8a43-4e17-8b7a-64fd877ad1f3",
+  "timestamp": "2025-05-12T09:00:00Z",
+  "simulationStep": 120,
+  "payload": {
+    "vesselId": 3,
+    "eta": "2025-05-12T09:30:00Z",
+    "position": { "x": 125.4, "y": 87.2 },
+    "capacity": 4,
+    "cargo": [
+      { "type": "Blade", "quantity": 2 },
+      { "type": "Tower", "quantity": 1 }
+    ]
+  }
+}
+```
+
+---
+
+この仕様は初期案であり、通信項目が増える場合には追記する。


### PR DESCRIPTION
## Summary
- document the Repast-side agent responsibilities and communications mapping to the existing C++ offshore workflow
- define JSON schemas describing the socket payloads exchanged between C++ and Repast components

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68dc980e5c14832f95863a73441b5481