### PR TITLE
Fix scenario path resolution for PortSimulationMain

### DIFF
--- a/src/test250930/PortSimulationMain.java
+++ b/src/test250930/PortSimulationMain.java
@@ -1,6 +1,7 @@
 package test250930;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import repast.simphony.runtime.RepastMain;
 
@@ -19,7 +20,8 @@ public class PortSimulationMain {
             return;
         }
 
-        String scenario = Path.of(DEFAULT_SCENARIO_PATH).toAbsolutePath().toString();
+        Path scenarioPath = Paths.get(DEFAULT_SCENARIO_PATH).toAbsolutePath();
+        String scenario = scenarioPath.toString();
         RepastMain.main(new String[] { "-scenario", scenario });
     }
 }


### PR DESCRIPTION
## Summary
- replace use of Path.of with Paths.get so the launcher works on Java 8 runtimes

## Testing
- ./scripts/setup_repast_runtime.sh
- find src/test250930 -name "*.java" -print0 | xargs -0 javac -cp "${CLASSPATH}" -d bin/test250930
- java -cp "bin/test250930:${CLASSPATH}" repast.simphony.batch.BatchMain "$(pwd)/test250930.rs"

------
https://chatgpt.com/codex/tasks/task_b_68dccf06887c832f864655e41517f903