### PR TITLE
Fix RepastMain launcher argument handling

### DIFF
--- a/src/test250930/PortSimulationMain.java
+++ b/src/test250930/PortSimulationMain.java
@@ -1,6 +1,9 @@
 package test250930;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import repast.simphony.runtime.RepastMain;
 
@@ -15,12 +18,41 @@ public class PortSimulationMain {
 
     public static void main(String[] args) {
         if (args.length > 0) {
-            RepastMain.main(args);
+            RepastMain.main(normaliseArgs(args));
             return;
         }
 
         File scenarioPath = new File(DEFAULT_SCENARIO_PATH).getAbsoluteFile();
-        String scenario = scenarioPath.getPath();
-        RepastMain.main(new String[] { "-scenario", scenario });
+        RepastMain.main(new String[] { scenarioPath.getPath() });
+    }
+
+    private static String[] normaliseArgs(String[] args) {
+        List<String> argList = Arrays.asList(args);
+        int scenarioFlagIndex = argList.indexOf("-scenario");
+
+        if (scenarioFlagIndex >= 0 && scenarioFlagIndex + 1 < args.length) {
+            String scenarioPath = absolutise(args[scenarioFlagIndex + 1]);
+            List<String> reordered = new ArrayList<>();
+            reordered.add(scenarioPath);
+            for (int i = 0; i < args.length; i++) {
+                if (i == scenarioFlagIndex || i == scenarioFlagIndex + 1) {
+                    continue;
+                }
+                reordered.add(args[i]);
+            }
+            return reordered.toArray(new String[0]);
+        }
+
+        if (args.length > 0 && !args[0].startsWith("-")) {
+            String[] copy = Arrays.copyOf(args, args.length);
+            copy[0] = absolutise(copy[0]);
+            return copy;
+        }
+
+        return args;
+    }
+
+    private static String absolutise(String path) {
+        return new File(path).getAbsoluteFile().getPath();
     }
 }


### PR DESCRIPTION
## Summary
- normalise the arguments that PortSimulationMain forwards to RepastMain so the runtime picks up the correct plugin root
- accept either a raw scenario directory or the legacy `-scenario <path>` pair and promote them to absolute paths before launching

## Testing
- find src/test250930 -name "*.java" -print0 | xargs -0 javac -cp "bin/test250930:$CLASSPATH" -d bin/test250930
- java -cp "bin/test250930:$CLASSPATH" repast.simphony.runtime.RepastMain "$(pwd)/test250930.rs" *(fails in the container's headless environment as expected)*

------
https://chatgpt.com/codex/tasks/task_b_68dce6d457f0832f8520ebe99b47eae6