### PR TITLE
Add console logging for Repast batch runs

### DIFF
--- a/src/test250930/PortArrivalScheduler.java
+++ b/src/test250930/PortArrivalScheduler.java
@@ -21,11 +21,15 @@ public class PortArrivalScheduler {
 
     public void registerArrival(VesselArrival arrival) {
         pendingArrivals.offer(arrival);
+        System.out.printf("[ArrivalScheduler] Queued Vessel %d for tick %d%n",
+                arrival.getVesselId(), arrival.getArrivalTick());
     }
 
     @ScheduledMethod(start = 1, interval = 1)
     public void step() {
         int currentTick = (int) Math.floor(RunEnvironment.getInstance().getCurrentSchedule().getTickCount());
+        System.out.printf("[ArrivalScheduler] Tick %d processing %d pending arrivals%n", currentTick,
+                pendingArrivals.size());
         while (!pendingArrivals.isEmpty() && pendingArrivals.peek().getArrivalTick() <= currentTick) {
             VesselArrival arrival = pendingArrivals.poll();
             VesselAgent vessel = new VesselAgent(arrival.getVesselId(), arrival.getArrivalTick(),

--- a/src/test250930/PortBuilder.java
+++ b/src/test250930/PortBuilder.java
@@ -6,6 +6,7 @@ import java.util.List;
 import repast.simphony.context.Context;
 import repast.simphony.context.DefaultContext;
 import repast.simphony.dataLoader.ContextBuilder;
+import repast.simphony.engine.environment.RunEnvironment;
 
 public class PortBuilder implements ContextBuilder<Object> {
 
@@ -19,6 +20,8 @@ public class PortBuilder implements ContextBuilder<Object> {
         QuayCraneAgent crane = new QuayCraneAgent(1, yard);
         DockAgent dock = new DockAgent(1, yard);
         PortArrivalScheduler arrivalScheduler = new PortArrivalScheduler(context, crane);
+
+        System.out.println("[PortBuilder] Initialising offshore port context");
 
         context.add(yard);
         context.add(crane);
@@ -41,10 +44,17 @@ public class PortBuilder implements ContextBuilder<Object> {
             arrivalScheduler.registerArrival(arrival);
         }
 
+        System.out.printf("[PortBuilder] Registered %d vessel arrivals%n", arrivals.size());
+
         Material foundation1 = Material.create(MaterialType.FOUNDATION, MaterialState.IN_TRANSIT);
         Material foundation2 = Material.create(MaterialType.FOUNDATION, MaterialState.IN_TRANSIT);
         dock.scheduleTow(foundation1);
         dock.scheduleTow(foundation2);
+
+        System.out.println("[PortBuilder] Scheduled initial foundation towing jobs");
+
+        RunEnvironment.getInstance().endAt(30);
+        System.out.println("[PortBuilder] Simulation will run until tick 30");
 
         return context;
     }


### PR DESCRIPTION
## Summary
- emit context setup and scheduling messages during PortBuilder initialisation
- log arrival queue registration and per-tick processing to confirm batch progress
- cap the run at tick 30 so the batch execution terminates with a visible summary

## Testing
- not run (Repast runtime libraries not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68ddea47ae70832fa2b904c91d1a4001