### PR TITLE
Add configurable logging for Repast batch runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ bin/*
 # Repast runtime cache
 lib/
 
-
 # IDE configuration
 .classpath
 .project
@@ -14,6 +13,7 @@ lib/
 
 # Logs and temporary files
 *.log*
+logs/
 
 # macOS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Repast Batch Logging Enhancements
+
+This scenario adds a lightweight logging subsystem so that Repast Simphony batch runs
+surface their progress without the full GUI.
+
+## Features
+
+* Console logging for major simulation events per tick.
+* Mirrored `.log` files stored under `logs/` with timestamps.
+* Optional CSV (`tick,agent_id,event,state`) and JSON (newline separated objects)
+  streams for downstream analytics.
+* Output modes controlled via a simple properties file.
+
+## Configuration
+
+Logging behaviour is configured through [`launch.props`](./launch.props). Set the
+`sim.logger.outputs` property to a comma-separated list of the desired targets:
+
+```
+sim.logger.outputs=console,file,csv,json
+```
+
+Supported values are:
+
+| Value   | Description                                                  |
+|---------|--------------------------------------------------------------|
+| `console` | Print messages directly to standard output.                  |
+| `file`    | Write the same messages to `logs/run_<timestamp>.log`.       |
+| `csv`     | Append structured events to `logs/run_<timestamp>.csv`.      |
+| `json`    | Append structured events as newline-delimited JSON objects to `logs/run_<timestamp>.json`. |
+
+If the property is omitted or empty the logger defaults to `console,file`.
+
+## Output Files
+
+Each run creates a new timestamped file for every enabled output mode under the
+`logs/` directory. The CSV and JSON formats capture the tick number, agent (or
+component) identifier, the event keyword, and a short state summary string. These
+files are designed to be lightweight inputs for Python / C++ post-processing.
+
+## Running the Scenario
+
+The batch entry point remains unchanged. From the project root:
+
+```bash
+java -cp "bin;${CLASSPATH_WIN}" repast.simphony.batch.BatchMain "$(pwd -W)/test250930.rs"
+```
+
+While the simulation runs you should now see tick-by-tick messages in the
+terminal, confirming that the model is active.

--- a/launch.props
+++ b/launch.props
@@ -1,0 +1,3 @@
+# Comma separated list of enabled logging outputs.
+# Valid entries: console, file, csv, json
+sim.logger.outputs=console,file,csv,json

--- a/sources.txt
+++ b/sources.txt
@@ -7,6 +7,7 @@ src/test250930/PortArrivalScheduler.java
 src/test250930/PortBuilder.java
 src/test250930/PortSimulationMain.java
 src/test250930/QuayCraneAgent.java
+src/test250930/SimLogger.java
 src/test250930/VesselAgent.java
 src/test250930/VesselArrival.java
 src/test250930/VesselStatus.java

--- a/src/test250930/DockAgent.java
+++ b/src/test250930/DockAgent.java
@@ -3,6 +3,7 @@ package test250930;
 import java.util.ArrayDeque;
 import java.util.Queue;
 
+import repast.simphony.engine.environment.RunEnvironment;
 import repast.simphony.engine.schedule.ScheduledMethod;
 
 public class DockAgent {
@@ -18,7 +19,8 @@ public class DockAgent {
 
     public void scheduleTow(Material foundation) {
         towQueue.offer(foundation);
-        System.out.printf("[Dock %d] Scheduled towing for %s%n", id, foundation.getId());
+        SimLogger.info(String.format("[Dock %d] Scheduled towing for %s", id, foundation.getId()));
+        SimLogger.event(0, "Dock-" + id, "tow_scheduled", "material=" + foundation.getId());
     }
 
     @ScheduledMethod(start = 2, interval = 3)
@@ -28,7 +30,8 @@ public class DockAgent {
         }
         Material foundation = towQueue.poll();
         foundation.setState(MaterialState.ON_QUAY);
-        System.out.printf("[Dock %d] Delivered %s to quay%n", id, foundation.getId());
+        int currentTick = (int) Math.floor(RunEnvironment.getInstance().getCurrentSchedule().getTickCount());
+        SimLogger.event(currentTick, "Dock-" + id, "towed_to_quay", "material=" + foundation.getId());
         yard.receiveMaterial(foundation, "dock " + id);
     }
 }

--- a/src/test250930/PortArrivalScheduler.java
+++ b/src/test250930/PortArrivalScheduler.java
@@ -21,22 +21,27 @@ public class PortArrivalScheduler {
 
     public void registerArrival(VesselArrival arrival) {
         pendingArrivals.offer(arrival);
-        System.out.printf("[ArrivalScheduler] Queued Vessel %d for tick %d%n",
-                arrival.getVesselId(), arrival.getArrivalTick());
+        SimLogger.info(String.format("[ArrivalScheduler] Queued Vessel %d for tick %d",
+                arrival.getVesselId(), arrival.getArrivalTick()));
+        SimLogger.event(0, "ArrivalScheduler",
+                "arrival_registered",
+                String.format("vessel=%d arrivalTick=%d", arrival.getVesselId(), arrival.getArrivalTick()));
     }
 
     @ScheduledMethod(start = 1, interval = 1)
     public void step() {
         int currentTick = (int) Math.floor(RunEnvironment.getInstance().getCurrentSchedule().getTickCount());
-        System.out.printf("[ArrivalScheduler] Tick %d processing %d pending arrivals%n", currentTick,
-                pendingArrivals.size());
+        SimLogger.event(currentTick, "ArrivalScheduler", "process_pending",
+                String.format("queueSize=%d", pendingArrivals.size()));
         while (!pendingArrivals.isEmpty() && pendingArrivals.peek().getArrivalTick() <= currentTick) {
             VesselArrival arrival = pendingArrivals.poll();
             VesselAgent vessel = new VesselAgent(arrival.getVesselId(), arrival.getArrivalTick(),
                     arrival.instantiateCargo(MaterialState.ON_VESSEL), crane);
             context.add(vessel);
-            System.out.printf("[ArrivalScheduler] Registered Vessel %d for arrival tick %d%n",
-                    arrival.getVesselId(), arrival.getArrivalTick());
+            SimLogger.info(String.format("[ArrivalScheduler] Registered Vessel %d for arrival tick %d",
+                    arrival.getVesselId(), arrival.getArrivalTick()));
+            SimLogger.event(currentTick, "ArrivalScheduler", "spawn_vessel",
+                    String.format("vessel=%d arrivalTick=%d", arrival.getVesselId(), arrival.getArrivalTick()));
         }
     }
 }

--- a/src/test250930/PortBuilder.java
+++ b/src/test250930/PortBuilder.java
@@ -21,7 +21,7 @@ public class PortBuilder implements ContextBuilder<Object> {
         DockAgent dock = new DockAgent(1, yard);
         PortArrivalScheduler arrivalScheduler = new PortArrivalScheduler(context, crane);
 
-        System.out.println("[PortBuilder] Initialising offshore port context");
+        SimLogger.info("[PortBuilder] Initialising offshore port context");
 
         context.add(yard);
         context.add(crane);
@@ -44,17 +44,17 @@ public class PortBuilder implements ContextBuilder<Object> {
             arrivalScheduler.registerArrival(arrival);
         }
 
-        System.out.printf("[PortBuilder] Registered %d vessel arrivals%n", arrivals.size());
+        SimLogger.info(String.format("[PortBuilder] Registered %d vessel arrivals", arrivals.size()));
 
         Material foundation1 = Material.create(MaterialType.FOUNDATION, MaterialState.IN_TRANSIT);
         Material foundation2 = Material.create(MaterialType.FOUNDATION, MaterialState.IN_TRANSIT);
         dock.scheduleTow(foundation1);
         dock.scheduleTow(foundation2);
 
-        System.out.println("[PortBuilder] Scheduled initial foundation towing jobs");
+        SimLogger.info("[PortBuilder] Scheduled initial foundation towing jobs");
 
         RunEnvironment.getInstance().endAt(30);
-        System.out.println("[PortBuilder] Simulation will run until tick 30");
+        SimLogger.info("[PortBuilder] Simulation will run until tick 30");
 
         return context;
     }

--- a/src/test250930/QuayCraneAgent.java
+++ b/src/test250930/QuayCraneAgent.java
@@ -4,6 +4,7 @@ import java.util.ArrayDeque;
 import java.util.Map;
 import java.util.Queue;
 
+import repast.simphony.engine.environment.RunEnvironment;
 import repast.simphony.engine.schedule.ScheduledMethod;
 
 public class QuayCraneAgent {
@@ -28,15 +29,18 @@ public class QuayCraneAgent {
     public void enqueueUnload(VesselAgent vessel, Material material) {
         int handling = HANDLING_TIMES.getOrDefault(material.getType(), 2);
         taskQueue.offer(new CraneTask(vessel, material, handling));
-        System.out.printf("[Crane %d] Queued unloading of %s from Vessel %d%n", id, material.getId(), vessel.getId());
+        int currentTick = (int) Math.floor(RunEnvironment.getInstance().getCurrentSchedule().getTickCount());
+        SimLogger.event(currentTick, "Crane-" + id, "queue_unload",
+                String.format("material=%s vessel=%d", material.getId(), vessel.getId()));
     }
 
     @ScheduledMethod(start = 1, interval = 1)
     public void step() {
         if (currentTask == null && !taskQueue.isEmpty()) {
             currentTask = taskQueue.poll();
-            System.out.printf("[Crane %d] Started unloading %s from Vessel %d%n", id,
-                    currentTask.getMaterial().getId(), currentTask.getVessel().getId());
+            int currentTick = (int) Math.floor(RunEnvironment.getInstance().getCurrentSchedule().getTickCount());
+            SimLogger.event(currentTick, "Crane-" + id, "start_unload",
+                    String.format("material=%s vessel=%d", currentTask.getMaterial().getId(), currentTask.getVessel().getId()));
         }
         if (currentTask != null) {
             currentTask.workOneTick();
@@ -45,7 +49,9 @@ public class QuayCraneAgent {
                 material.setState(MaterialState.ON_QUAY);
                 yard.receiveMaterial(material, "crane " + id);
                 currentTask.getVessel().notifyMaterialUnloaded(material);
-                System.out.printf("[Crane %d] Completed unloading %s%n", id, material.getId());
+                int currentTick = (int) Math.floor(RunEnvironment.getInstance().getCurrentSchedule().getTickCount());
+                SimLogger.event(currentTick, "Crane-" + id, "complete_unload",
+                        String.format("material=%s vessel=%d", material.getId(), currentTask.getVessel().getId()));
                 currentTask = null;
             }
         }

--- a/src/test250930/SimLogger.java
+++ b/src/test250930/SimLogger.java
@@ -1,0 +1,213 @@
+package test250930;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * Lightweight logger that mirrors messages to the console, structured log files and
+ * optional CSV / JSON streams depending on the configured output modes.
+ */
+public final class SimLogger {
+
+    private static final String CONFIG_FILE = "launch.props";
+    private static final String OUTPUT_PROPERTY = "sim.logger.outputs";
+    private static final DateTimeFormatter RUN_ID_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
+
+    private static final SimLogger INSTANCE = new SimLogger();
+
+    private final EnumSet<OutputMode> modes;
+    private final Object lock = new Object();
+    private final PrintWriter logWriter;
+    private final PrintWriter csvWriter;
+    private final PrintWriter jsonWriter;
+
+    private SimLogger() {
+        Properties properties = loadProperties();
+        this.modes = parseModes(properties.getProperty(OUTPUT_PROPERTY));
+        String runId = LocalDateTime.now().format(RUN_ID_FORMAT);
+        Path logsDir = Paths.get("logs");
+        ensureDirectory(logsDir);
+
+        this.logWriter = modes.contains(OutputMode.FILE) ? createWriter(logsDir.resolve("run_" + runId + ".log")) : null;
+        this.csvWriter = modes.contains(OutputMode.CSV) ? createCsvWriter(logsDir.resolve("run_" + runId + ".csv")) : null;
+        this.jsonWriter = modes.contains(OutputMode.JSON) ? createWriter(logsDir.resolve("run_" + runId + ".json")) : null;
+
+        Runtime.getRuntime().addShutdownHook(new Thread(this::closeWriters, "sim-logger-shutdown"));
+
+        info("Simulation logging initialised with modes: " + modes);
+    }
+
+    public static void info(String message) {
+        INSTANCE.writeInfo(message);
+    }
+
+    public static void event(int tick, String agentId, String event, String state) {
+        INSTANCE.writeEvent(tick, agentId, event, state);
+    }
+
+    private void writeInfo(String message) {
+        synchronized (lock) {
+            if (modes.contains(OutputMode.CONSOLE)) {
+                System.out.println(message);
+            }
+            if (logWriter != null) {
+                logWriter.println(message);
+                logWriter.flush();
+            }
+        }
+    }
+
+    private void writeEvent(int tick, String agentId, String event, String state) {
+        String infoLine = String.format(Locale.ROOT, "[Tick %d] [%s] %s (%s)", tick, agentId, event, state);
+        synchronized (lock) {
+            writeInfo(infoLine);
+            if (csvWriter != null) {
+                csvWriter.printf(Locale.ROOT, "%d,%s,%s,%s%n", tick, escapeCsv(agentId), escapeCsv(event), escapeCsv(state));
+                csvWriter.flush();
+            }
+            if (jsonWriter != null) {
+                jsonWriter.println('{'
+                        + "\"tick\":" + tick + ','
+                        + "\"agentId\":" + quoteJson(agentId) + ','
+                        + "\"event\":" + quoteJson(event) + ','
+                        + "\"state\":" + quoteJson(state)
+                        + "}");
+                jsonWriter.flush();
+            }
+        }
+    }
+
+    private Properties loadProperties() {
+        Properties properties = new Properties();
+        Path config = Paths.get(CONFIG_FILE);
+        if (!Files.exists(config)) {
+            return properties;
+        }
+        try (var in = Files.newInputStream(config)) {
+            properties.load(in);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to load logger configuration", e);
+        }
+        return properties;
+    }
+
+    private EnumSet<OutputMode> parseModes(String configured) {
+        EnumSet<OutputMode> selected = EnumSet.noneOf(OutputMode.class);
+        if (configured == null || configured.isBlank()) {
+            selected.add(OutputMode.CONSOLE);
+            selected.add(OutputMode.FILE);
+            return selected;
+        }
+        String[] tokens = configured.split(",");
+        for (String token : tokens) {
+            OutputMode mode = OutputMode.fromName(token.trim());
+            if (mode != null) {
+                selected.add(mode);
+            }
+        }
+        if (selected.isEmpty()) {
+            selected.add(OutputMode.CONSOLE);
+            selected.add(OutputMode.FILE);
+        }
+        return selected;
+    }
+
+    private void ensureDirectory(Path directory) {
+        try {
+            Files.createDirectories(directory);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create log directory", e);
+        }
+    }
+
+    private PrintWriter createWriter(Path path) {
+        try {
+            return new PrintWriter(new BufferedWriter(new OutputStreamWriter(Files.newOutputStream(path), StandardCharsets.UTF_8)), true);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to open log file: " + path, e);
+        }
+    }
+
+    private PrintWriter createCsvWriter(Path path) {
+        PrintWriter writer = createWriter(path);
+        writer.println("tick,agent_id,event,state");
+        return writer;
+    }
+
+    private void closeWriters() {
+        synchronized (lock) {
+            if (jsonWriter != null) {
+                jsonWriter.close();
+            }
+            if (csvWriter != null) {
+                csvWriter.close();
+            }
+            if (logWriter != null) {
+                logWriter.close();
+            }
+        }
+    }
+
+    private static String escapeCsv(String value) {
+        String safe = Objects.toString(value, "");
+        if (safe.contains(",") || safe.contains("\"") || safe.contains("\n")) {
+            safe = '"' + safe.replace("\"", "\"\"") + '"';
+        }
+        return safe;
+    }
+
+    private static String quoteJson(String value) {
+        String safe = Objects.toString(value, "");
+        StringBuilder builder = new StringBuilder();
+        builder.append('"');
+        for (char ch : safe.toCharArray()) {
+            switch (ch) {
+                case '\\':
+                case '"':
+                    builder.append('\\').append(ch);
+                    break;
+                case '\n':
+                    builder.append("\\n");
+                    break;
+                case '\r':
+                    builder.append("\\r");
+                    break;
+                case '\t':
+                    builder.append("\\t");
+                    break;
+                default:
+                    builder.append(ch);
+            }
+        }
+        builder.append('"');
+        return builder.toString();
+    }
+
+    private enum OutputMode {
+        CONSOLE,
+        FILE,
+        CSV,
+        JSON;
+
+        static OutputMode fromName(String name) {
+            return Arrays.stream(values())
+                    .filter(mode -> mode.name().equalsIgnoreCase(name))
+                    .findFirst()
+                    .orElse(null);
+        }
+    }
+}

--- a/src/test250930/VesselAgent.java
+++ b/src/test250930/VesselAgent.java
@@ -33,14 +33,14 @@ public class VesselAgent {
         int currentTick = (int) Math.floor(RunEnvironment.getInstance().getCurrentSchedule().getTickCount());
         if (status == VesselStatus.AT_SEA && currentTick >= arrivalTick) {
             status = VesselStatus.AT_QUAY;
-            System.out.printf("[Vessel %d] Arrived at tick %d with %d cargo items%n", id, currentTick, cargoQueue.size());
+            SimLogger.event(currentTick, "Vessel-" + id, "arrived", "cargo=" + cargoQueue.size());
         }
         if (status == VesselStatus.AT_QUAY || status == VesselStatus.UNLOADING) {
             requestNextUnload();
             if (cargoQueue.isEmpty() && unloading.isEmpty()) {
                 if (status != VesselStatus.COMPLETED) {
                     status = VesselStatus.COMPLETED;
-                    System.out.printf("[Vessel %d] Completed unloading and ready to depart%n", id);
+                    SimLogger.event(currentTick, "Vessel-" + id, "depart_ready", "cargo=0");
                 }
             }
         }
@@ -56,6 +56,8 @@ public class VesselAgent {
             unloading.add(next);
             crane.enqueueUnload(this, next);
             status = VesselStatus.UNLOADING;
+            int currentTick = (int) Math.floor(RunEnvironment.getInstance().getCurrentSchedule().getTickCount());
+            SimLogger.event(currentTick, "Vessel-" + id, "request_unload", "material=" + next.getId());
         }
     }
 
@@ -67,5 +69,8 @@ public class VesselAgent {
         if (!cargoQueue.isEmpty()) {
             status = VesselStatus.AT_QUAY;
         }
+        int currentTick = (int) Math.floor(RunEnvironment.getInstance().getCurrentSchedule().getTickCount());
+        SimLogger.event(currentTick, "Vessel-" + id, "material_unloaded",
+                String.format("material=%s remaining=%d", material.getId(), cargoQueue.size()));
     }
 }

--- a/src/test250930/YardAgent.java
+++ b/src/test250930/YardAgent.java
@@ -5,6 +5,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
+import repast.simphony.engine.environment.RunEnvironment;
 import repast.simphony.engine.schedule.ScheduledMethod;
 
 public class YardAgent {
@@ -22,15 +23,21 @@ public class YardAgent {
     public void receiveMaterial(Material material, String source) {
         material.setState(MaterialState.IN_YARD);
         inventory.get(material.getType()).add(material);
-        System.out.printf("[Yard %d] Stored %s delivered from %s. Current stock: %d%n", id,
-                material.getId(), source, inventory.get(material.getType()).size());
+        int currentTick = (int) Math.floor(RunEnvironment.getInstance().getCurrentSchedule().getTickCount());
+        int stock = inventory.get(material.getType()).size();
+        SimLogger.event(currentTick, "Yard-" + id, "store_material",
+                String.format("material=%s type=%s stock=%d source=%s", material.getId(),
+                        material.getType(), stock, source));
     }
 
     @ScheduledMethod(start = 5, interval = 5)
     public void inventoryReport() {
-        System.out.printf("[Yard %d] Inventory report:%n", id);
+        int currentTick = (int) Math.floor(RunEnvironment.getInstance().getCurrentSchedule().getTickCount());
+        SimLogger.info(String.format("[Yard %d] Inventory report at tick %d", id, currentTick));
         for (Map.Entry<MaterialType, List<Material>> entry : inventory.entrySet()) {
-            System.out.printf("  - %s: %d items%n", entry.getKey(), entry.getValue().size());
+            SimLogger.info(String.format("  - %s: %d items", entry.getKey(), entry.getValue().size()));
+            SimLogger.event(currentTick, "Yard-" + id, "inventory",
+                    String.format("type=%s stock=%d", entry.getKey(), entry.getValue().size()));
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a configurable `SimLogger` that mirrors events to console, log files, CSV, and JSON based on `launch.props`
- switch existing agents to use the shared logger for tick-level messages and include the new source in build metadata
- document the logging workflow and ignore generated log directories

## Testing
- not run (Repast Simphony runtime libraries are unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68de2b3fba38832f80c73cab2dba62ff