### PR TITLE
Document batch run workflow and add Repast sweeper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ lib/
 
 # Logs and temporary files
 *.log*
+test250930.rs/logs/
 
 # macOS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@ for downstream tooling.
 ## Running the simulation
 
 ```bash
-java -cp "bin;${CLASSPATH_WIN}" repast.simphony.batch.BatchMain "$(pwd -W)/test250930.rs"
+java --add-opens java.base/java.lang=ALL-UNNAMED \
+  -cp "bin;${CLASSPATH_WIN}" \
+  repast.simphony.runtime.RepastBatchMain \
+  -params "$(pwd -W)\\test250930.rs\\batch_params.xml" \
+  "$(pwd -W)\\test250930.rs"
 ```
 
-During execution the logger writes directly to `System.out`, so messages become visible even
-under batch mode.
+The accompanying `test250930.rs/batch_params.xml` sweeper requests a single run and is required
+when invoking the batch launcher. During execution the logger writes directly to `System.out`, so
+messages become visible even under batch mode.
 
 ## Configuring log outputs
 

--- a/docs/container-repast-runtime.md
+++ b/docs/container-repast-runtime.md
@@ -31,12 +31,12 @@ CLASSPATH=$(./scripts/repast_classpath.sh)
 ## 2. Compile the model code
 
 Once the runtime is in place the sources can be compiled against it. The commands
-below recompile the `src/test250930` package into the existing `bin/test250930`
+below recompile the `src/test250930` package into the existing `bin`
 output directory:
 
 ```bash
 find src/test250930 -name "*.java" -print0 \
-  | xargs -0 javac -cp "$CLASSPATH" -d bin/test250930
+  | xargs -0 javac -cp "$CLASSPATH" -d bin
 ```
 
 The compiler will emit a warning about annotation processors being discovered on
@@ -49,9 +49,16 @@ in the container. Use the batch runner instead. Passing the absolute path to the
 scenario directory is important because the bundled `user_path.xml` uses relative
 entries such as `../bin` and `../lib`.
 
+Repast Simphony 2.11 ships with a parameter sweeper that drives batch runs. The
+included `test250930.rs/batch_params.xml` file requests a single iteration and is
+referenced via the `-params` flag.
+
 ```bash
-java -cp "bin/test250930:$CLASSPATH" \
-  repast.simphony.batch.BatchMain "$(pwd)/test250930.rs"
+java --add-opens java.base/java.lang=ALL-UNNAMED \
+  -cp "bin:$CLASSPATH" \
+  repast.simphony.runtime.RepastBatchMain \
+  -params "$(pwd)/test250930.rs/batch_params.xml" \
+  "$(pwd)/test250930.rs"
 ```
 
 This will load `test250930.rs/scenario.xml`, initialise the context defined in

--- a/docs/repast_runtime_summary_ja.md
+++ b/docs/repast_runtime_summary_ja.md
@@ -59,13 +59,13 @@ $env:CLASSPATH_WIN = (Get-Content .\lib\repast-2.11.0\classpath.txt | Where-Obje
 
 ```bash
 find src/test250930 -name "*.java" -print0 \
-  | xargs -0 javac -cp "${CLASSPATH}" -d bin/test250930
+  | xargs -0 javac -cp "${CLASSPATH}" -d bin
 ```
 
 - `find ... -print0` はファイル名にスペースが含まれても安全に処理できるよう終端を NUL 文字に
   しています。
 - `xargs -0` が `find` の出力を受け取り、`javac` にまとめて渡します。
-- `-cp "${CLASSPATH}"` で先ほど生成した Repast 依存のクラスパスを指定し、`-d bin/test250930` で
+- `-cp "${CLASSPATH}"` で先ほど生成した Repast 依存のクラスパスを指定し、`-d bin` で
   バイトコードの出力先を既存の `bin` ディレクトリに揃えます。
 
 Windows 環境であれば `Get-ChildItem` などを組み合わせても構いませんが、WSL や Git Bash を使用
@@ -78,16 +78,26 @@ Windows 環境であれば `Get-ChildItem` などを組み合わせても構い�
 
 ### 5.1 Linux / macOS
 
+`test250930.rs/batch_params.xml` には単一実行を指示するパラメータスイープが定義されています。
+バッチランナーを呼ぶ際は `-params` オプションでこのファイルを渡し、JDK17 以降で必須となる
+`--add-opens` オプションも併せて指定します。
+
 ```bash
-java -cp "bin/test250930:${CLASSPATH}" \
-  repast.simphony.batch.BatchMain "$(pwd)/test250930.rs"
+java --add-opens java.base/java.lang=ALL-UNNAMED \
+  -cp "bin:${CLASSPATH}" \
+  repast.simphony.runtime.RepastBatchMain \
+  -params "$(pwd)/test250930.rs/batch_params.xml" \
+  "$(pwd)/test250930.rs"
 ```
 
 ### 5.2 Windows（ユーザー指定コマンド）
 
 ```powershell
-java -cp "bin;${env:CLASSPATH_WIN}" `
-  repast.simphony.runtime.RepastBatchMain "$(Get-Location)\test250930.rs"
+java --add-opens java.base/java.lang=ALL-UNNAMED `
+  -cp "bin;${env:CLASSPATH_WIN}" `
+  repast.simphony.runtime.RepastBatchMain `
+  -params "$(Get-Location)\test250930.rs\batch_params.xml" `
+  "$(Get-Location)\test250930.rs"
 ```
 
 `RepastBatchMain` は `BatchMain` と同様に GUI を起動せず、`launch.props` の設定を参照して
@@ -105,12 +115,18 @@ java -cp "bin;${env:CLASSPATH_WIN}" `
 
 ```bash
 # ✅ 正しい例（Git Bash / MINGW64）
-java -cp "bin;${CLASSPATH_WIN}" \
-  repast.simphony.runtime.RepastBatchMain "$(pwd -W)\\test250930.rs"
+java --add-opens java.base/java.lang=ALL-UNNAMED \
+  -cp "bin;${CLASSPATH_WIN}" \
+  repast.simphony.runtime.RepastBatchMain \
+  -params "$(pwd -W)\\test250930.rs\\batch_params.xml" \
+  "$(pwd -W)\\test250930.rs"
 
-# ❌ 誤った例
-java -cp "bin;${CLASSPATH_WIN}" \
-  repast.simphony.runtime.RepastBatchMain ./test250930.rs/scenario.xml
+# ❌ 誤った例（scenario.xml を直接指定してしまうケース）
+java --add-opens java.base/java.lang=ALL-UNNAMED \
+  -cp "bin;${CLASSPATH_WIN}" \
+  repast.simphony.runtime.RepastBatchMain \
+  -params "$(pwd -W)\\test250930.rs\\batch_params.xml" \
+  ./test250930.rs/scenario.xml
 ```
 
 ### 6.2 `unknown plug-in ID - saf.core.runtime`

--- a/test250930.rs/batch_params.xml
+++ b/test250930.rs/batch_params.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sweep runs="1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="batch_params.xsd">
+  <parameter name="randomSeed" type="constant" constant_type="number" value="1"/>
+</sweep>

--- a/test250930.rs/launch.props
+++ b/test250930.rs/launch.props
@@ -2,7 +2,7 @@
 #Wed Oct 01 09:36:00 JST 2025
 incoming=tcp\://127.0.0.1\:5555
 outgoing=tcp\://127.0.0.1\:5556
-scenario=..\\test250930.rs
+scenario=../test250930.rs
 working.directory=../
 logging.outputs=console,file,csv,json
 logging.directory=logs


### PR DESCRIPTION
## Summary
- add a minimal `batch_params.xml` sweeper and document the required `--add-opens` JVM flag for batch execution
- update the English and Japanese runtime guides plus the README with the corrected compilation and launch commands
- normalise the scenario path in `launch.props` and ignore generated log folders so runs succeed on Linux and Windows

## Testing
- java --add-opens java.base/java.lang=ALL-UNNAMED -cp "bin:$CLASSPATH" repast.simphony.runtime.RepastBatchMain -params "$(pwd)/test250930.rs/batch_params.xml" "$(pwd)/test250930.rs"

------
https://chatgpt.com/codex/tasks/task_b_68de38a4cca0832f8f96a7ed30d0d5c0